### PR TITLE
Added ability to define a break iterator type when getting lines

### DIFF
--- a/source/layoutex/ParagraphLayout.cpp
+++ b/source/layoutex/ParagraphLayout.cpp
@@ -662,7 +662,7 @@ le_bool ParagraphLayout::isDone() const
     return fLineEnd >= fCharCount;
 }
 
-ParagraphLayout::Line *ParagraphLayout::nextLine(float width)
+ParagraphLayout::Line *ParagraphLayout::nextLine(float width, UBreakIteratorType kind)
 {
     if (isDone()) {
         return NULL;
@@ -689,7 +689,7 @@ ParagraphLayout::Line *ParagraphLayout::nextLine(float width)
             glyph += 1;
         }
 
-        fLineEnd = previousBreak(fGlyphToCharMap[glyph]);
+        fLineEnd = previousBreak(fGlyphToCharMap[glyph], kind);
 
         // If this break is at or before the last one,
         // find a glyph, starting at the one which didn't
@@ -979,7 +979,7 @@ le_bool ParagraphLayout::isComplex(UScriptCode script)
     return complexTable[script];
 }
 
-le_int32 ParagraphLayout::previousBreak(le_int32 charIndex)
+le_int32 ParagraphLayout::previousBreak(le_int32 charIndex, UBreakIteratorType kind)
 {
     // skip over any whitespace or control characters,
     // because they can hang in the margin.
@@ -995,7 +995,19 @@ le_int32 ParagraphLayout::previousBreak(le_int32 charIndex)
         UCharCharacterIterator *iter = new UCharCharacterIterator(fChars, fCharCount);
         UErrorCode status = U_ZERO_ERROR;
 
-        fBreakIterator = BreakIterator::createLineInstance(thai, status);
+        // Set the break iterator; default is line breaks
+        if (kind == UBreakIteratorType::UBRK_CHARACTER) {
+            fBreakIterator = BreakIterator::createCharacterInstance(thai, status);
+        } else if (kind == UBreakIteratorType::UBRK_WORD) {
+            fBreakIterator = BreakIterator::createWordInstance(thai, status);
+        } else if (kind == UBreakIteratorType::UBRK_SENTENCE) {
+            fBreakIterator = BreakIterator::createSentenceInstance(thai, status);
+        } else if (kind == UBreakIteratorType::UBRK_TITLE) {
+            fBreakIterator = BreakIterator::createTitleInstance(thai, status);
+        } else {
+            fBreakIterator = BreakIterator::createLineInstance(thai, status);
+        }
+        
         fBreakIterator->adoptText(iter);
     }
 

--- a/source/layoutex/layout/ParagraphLayout.h
+++ b/source/layoutex/layout/ParagraphLayout.h
@@ -528,6 +528,9 @@ public:
      *              to zero, a <code>ParagraphLayout::Line</code> object representing the
      *              rest of the paragraph will be returned.
      *
+     * @param kind denotes the type of break iterator used when truncating line to fit in in width.
+     *             Default is UBRK_LINE to stay in line with stock ICU.
+     *
      * @return a <code>ParagraphLayout::Line</code> object which represents the line. The caller
      *         is responsible for deleting the object. Returns <code>NULL</code> if there are no
      *         more lines in the paragraph.
@@ -536,7 +539,7 @@ public:
      *
      * @stable ICU 3.2
      */
-    Line *nextLine(float width);
+    Line *nextLine(float width, UBreakIteratorType kind = UBreakIteratorType::UBRK_LINE);
 
     /**
      * ICU "poor man's RTTI", returns a UClassID for this class.
@@ -599,7 +602,7 @@ private:
 
     static le_bool isComplex(UScriptCode script);
 
-    le_int32 previousBreak(le_int32 charIndex);
+    le_int32 previousBreak(le_int32 charIndex, UBreakIteratorType kind = UBreakIteratorType::UBRK_LINE);
 
 
     const LEUnicode *fChars;


### PR DESCRIPTION
- By default, ICU only allows you to create line instances while truncating to a specific width per-word. This PR allows you to specify how you would like to truncate, allowing for all of the UBreakIteratorTypes provided by ICU.

- Default parameters added to each function using UBreakIteratorType in order to not introduce any breaking changes